### PR TITLE
feat: enhance GitOps integration with workstation cluster support

### DIFF
--- a/.devcontainer/commands/initializeCommand.sh
+++ b/.devcontainer/commands/initializeCommand.sh
@@ -26,7 +26,6 @@ CONTAINER_NODE_MODULES_DIR_PATH=${containerWorkspaceFolder}/node_modules
 CONTAINER_GEMINI_CONFIG_DIR_PATH=/home/vscode/.gemini
 
 # Unonymous Volume Arguments
-HOST_WORKSTATION_KUBE_CONFIG_FILE_PATH=$HOME/.kube/config
 CONTAINER_KUBE_CONFIG_DIR_PATH=${containerWorkspaceFolder}/.kube
 CONTAINER_WORKSTATION_KUBE_CONFIG_FILE_PATH=${containerWorkspaceFolder}/.kube/workstation.config
 

--- a/.devcontainer/commands/updateContentCommand.sh
+++ b/.devcontainer/commands/updateContentCommand.sh
@@ -31,5 +31,9 @@ install_npm_packages() {
 export -f install_oci install_helm install_npm_packages
 parallel --jobs 10 ::: install_oci install_helm install_npm_packages
 
+echo "🔄 Copying kubeconfig files"
+mkdir -p $CONTAINER_KUBE_CONFIG_DIR_PATH
+cp $CONTAINER_SECRETS_DIR_PATH/k8s/* $CONTAINER_KUBE_CONFIG_DIR_PATH
+
 echo "🔄 Start synchronization"
 ./.devcontainer/commands/common/synchronizeProject.sh

--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       TZ: 'Asia/Seoul'
       IS_DEV_CONTAINER: true
       ENABLE_AUTO_SYNC: true
-      DIR_PATHS_TO_CHANGE_OWNER: ${CONTAINER_NODE_MODULES_DIR_PATH} ${CONTAINER_GEMINI_CONFIG_DIR_PATH} ${CONTAINER_KUBE_CONFIG_DIR_PATH}
+      DIR_PATHS_TO_CHANGE_OWNER: ${CONTAINER_NODE_MODULES_DIR_PATH} ${CONTAINER_GEMINI_CONFIG_DIR_PATH}
 
     env_file:
       - .env
@@ -20,8 +20,6 @@ services:
       - ..:${containerWorkspaceFolder}:cached
       # Mount Secrets
       - ${HOST_SECRETS_DIR_PATH}:${CONTAINER_SECRETS_DIR_PATH}
-      # Mount Local(Workstation) kubeconfig
-      - ${HOST_WORKSTATION_KUBE_CONFIG_FILE_PATH}:${CONTAINER_WORKSTATION_KUBE_CONFIG_FILE_PATH}
       # Named Volume
       ## Node Modules
       - ApexCaptain.IaC.Workspace.node_modules:${CONTAINER_NODE_MODULES_DIR_PATH}

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -452,6 +452,7 @@ void (async () => {
                   process.env.OKE_ARGOCD_APP_ARGOCD_ADMIN_PASSWORD!!,
                 adminPasswordBcryted:
                   process.env.OKE_ARGOCD_APP_ARGOCD_ADMIN_PASSWORD_BCRYPTED!!,
+                workstationClusterServer: `https://${process.env.WORKSTATION_COMMON_DOMAIN_IPTIME}:${process.env.WORKSTATION_COMMON_K8S_CONTROL_PLANE_EXTERNAL_PORT}`,
               },
               monitoring: {
                 grafana: {

--- a/src/terraform/stacks/k8s/oke/.schema.ts
+++ b/src/terraform/stacks/k8s/oke/.schema.ts
@@ -5,6 +5,7 @@ export const OkeSchema = Joi.object({
     argoCd: Joi.object({
       adminPassword: Joi.string().required(),
       adminPasswordBcryted: Joi.string().required(),
+      workstationClusterServer: Joi.string().required(),
     }).required(),
     monitoring: Joi.object({
       grafana: Joi.object({

--- a/src/terraform/stacks/k8s/workstation/apps/git-ops.stack.ts
+++ b/src/terraform/stacks/k8s/workstation/apps/git-ops.stack.ts
@@ -1,0 +1,36 @@
+import { AbstractStack } from '@/common';
+import { TerraformAppService } from '@/terraform/terraform.app.service';
+import { TerraformConfigService } from '@/terraform/terraform.config.service';
+import { KubernetesProvider } from '@lib/terraform/providers/kubernetes/provider';
+import { NullProvider } from '@lib/terraform/providers/null/provider';
+import { Injectable } from '@nestjs/common';
+import { LocalBackend } from 'cdktf';
+import _ from 'lodash';
+
+@Injectable()
+export class K8S_Workstation_Apps_GitOps_Stack extends AbstractStack {
+  terraform = {
+    backend: this.backend(LocalBackend, () =>
+      this.terraformConfigService.backends.localBackend.secrets({
+        stackName: this.id,
+      }),
+    ),
+    providers: {
+      null: this.provide(NullProvider, 'nullProvider', () => ({})),
+      kubernetes: this.provide(KubernetesProvider, 'kubernetesProvider', () =>
+        this.terraformConfigService.providers.kubernetes.ApexCaptain.workstation(),
+      ),
+    },
+  };
+
+  constructor(
+    private readonly terraformAppService: TerraformAppService,
+    private readonly terraformConfigService: TerraformConfigService,
+  ) {
+    super(
+      terraformAppService.cdktfApp,
+      K8S_Workstation_Apps_GitOps_Stack.name,
+      'GitOps stack for workstation k8s',
+    );
+  }
+}

--- a/src/terraform/stacks/k8s/workstation/apps/index.ts
+++ b/src/terraform/stacks/k8s/workstation/apps/index.ts
@@ -31,3 +31,6 @@ export * from './ingress-controller.stack';
 
 // monitoring
 export * from './monitoring.stack';
+
+// git-ops
+export * from './git-ops.stack';

--- a/src/terraform/stacks/project/apps/number-planet.stack.ts
+++ b/src/terraform/stacks/project/apps/number-planet.stack.ts
@@ -20,6 +20,7 @@ import { Cloudflare_Record_Stack } from '../../cloudflare/record.stack';
 import { Ocir_Stack } from '../../ocir.stack';
 import { K8S_Oke_Apps_GitOps_Stack } from '../../k8s/oke/apps/git-ops.stack';
 import { GitOps_Stack } from '../../git-ops.stack';
+import { K8S_Workstation_Apps_GitOps_Stack } from '../../k8s/workstation/apps/git-ops.stack';
 
 @Injectable()
 export class Project_Apps_NumberPlanet_Stack extends AbstractStack {
@@ -196,6 +197,7 @@ export class Project_Apps_NumberPlanet_Stack extends AbstractStack {
     private readonly ocirStack: Ocir_Stack,
     private readonly k8sOkeAppsArgoCdResourcesStack: K8S_Oke_Apps_ArgoCd_Resources_Stack,
     private readonly k8sOkeAppsGitOpsStack: K8S_Oke_Apps_GitOps_Stack,
+    private readonly k8sWorkstationAppsGitOpsStack: K8S_Workstation_Apps_GitOps_Stack,
     private readonly cloudflareRecordStack: Cloudflare_Record_Stack,
     private readonly gitOpsProjectStack: GitOps_Stack,
   ) {


### PR DESCRIPTION
- ArgoCD에 워크스테이션 클러스터 설정 추가
- 워크스테이션 클러스터 관리를 위한 서비스 어카운트 및 RBAC 구현
- 워크스테이션 Kubernetes용 전용 GitOps 스택 생성
- kubeconfig 파일 처리를 위한 devcontainer 설정 업데이트
- OKE 스키마에 워크스테이션 클러스터 서버 설정 추가
- ArgoCD 클러스터 관리와 워크스테이션 클러스터 통합
- 직접 kubeconfig 마운팅 대신 시크릿 기반 접근 방식으로 변경
- 보안 인증을 위한 워크스테이션 클러스터 토큰 관리 추가

Fixes #